### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,3 +58,5 @@ List below is the official list of TOC contributors, in alphabetical order:
 * Yaron Haviv, iguazio (yaronh@iguaz.io)
 * Yong Tang, Infoblox (ytang@infoblox.com)
 * Yuri Shkuro, Uber	(ys@uber.com)
+* Rae Wang, Google (raew@google.com)
+* Ray Colline, Google (rayc@google.com)


### PR DESCRIPTION
Adding Rae and Ray from Google. We lead PM and eng of Cloud IAM and resource management. Also part of K8S Sig-Auth